### PR TITLE
Fixed whitespace bug and bug in speccal

### DIFF
--- a/saltspec/speccal.py
+++ b/saltspec/speccal.py
@@ -149,7 +149,7 @@ def calfunc(obs_spectra, std_spectra, ext_spectra, airmass, exptime, error=False
 
    #correct the error calc
    if error:
-      cal_spectra.sigma=obs_spectra.sigma*cal_spectra.flux/obs_spectra.flux
+      cal_spectra.var = obs_spectra.var * cal_spectra.flux / obs_spectra.flux
 
    return cal_spectra
 

--- a/saltspec/specidentify.py
+++ b/saltspec/specidentify.py
@@ -137,7 +137,7 @@ def specidentify(images,linelist, outfile, guesstype='rss', guessfile='',      \
                       xpixscale=0.1267*xbin
                       ypixscale=0.1267*ybin
                       cx=int(3162/xbin)
-	              cy=int(2050/ybin)
+                      cy=int(2050/ybin)
 
 
                       x,y=mt.convert_fromsky(ras,des, rac,dec, xpixscale=xpixscale, ypixscale=ypixscale,


### PR DESCRIPTION
The bug in speccal was referencing sigma and var, which is suppose to be the error plane.   However, error plans are not fully support yet in specred in v0.47
