### PR TITLE
fix for #46 for salt2iraf ascardlist depreciation

### DIFF
--- a/saltred/salt2iraf.py
+++ b/saltred/salt2iraf.py
@@ -2,32 +2,6 @@
 # Copyright (c) 2009, South African Astronomical Observatory (SAAO)        #
 # All rights reserved.                                                     #
 #                                                                          #
-# Redistribution and use in source and binary forms, with or without       #
-# modification, are permitted provided that the following conditions       #
-# are met:                                                                 #
-#                                                                          #
-#     * Redistributions of source code must retain the above copyright     #
-#       notice, this list of conditions and the following disclaimer.      #
-#     * Redistributions in binary form must reproduce the above copyright  #
-#       notice, this list of conditions and the following disclaimer       #
-#       in the documentation and/or other materials provided with the      #
-#       distribution.                                                      #
-#     * Neither the name of the South African Astronomical Observatory     #
-#       (SAAO) nor the names of its contributors may be used to endorse    #
-#       or promote products derived from this software without specific    #
-#       prior written permission.                                          #
-#                                                                          #
-# THIS SOFTWARE IS PROVIDED BY THE SAAO ''AS IS'' AND ANY EXPRESS OR       #
-# IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED           #
-# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE   #
-# DISCLAIMED. IN NO EVENT SHALL THE SAAO BE LIABLE FOR ANY                 #
-# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL       #
-# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS  #
-# OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)    #
-# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,      #
-# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN #
-# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE          #
-# POSSIBILITY OF SUCH DAMAGE.                                              #
 ############################################################################
 
 #!/usr/bin/env python
@@ -45,7 +19,7 @@ are ready to work with basic IRAF tasks
 # Ensure Python 2.5 compatibility
 from __future__ import with_statement
 
-import pyfits
+from astropy.io import fits
 from pyraf import iraf
 from pyraf.iraf import pysalt
 
@@ -86,7 +60,7 @@ def convertsalt(img, oimg, ext=1, clobber=True):
    """Convert a SALT MEF file into a single extension fits file"""
 
    #open the image
-   hdu=saltio.openfits(img)
+   hdu=fits.open(img)
 
    #if len one, copy and return
    if len(hdu)==1:  
@@ -94,10 +68,11 @@ def convertsalt(img, oimg, ext=1, clobber=True):
       return
 
    #create the new output image
-   odu = pyfits.PrimaryHDU(data=hdu[ext].data, header=hdu[0].header)
+   odu = fits.PrimaryHDU(data=hdu[ext].data, header=hdu[0].header)
 
    #combine the headers from the primary and first exention
-   for c in hdu[ext].header.ascardlist(): odu.header.update(c.key, c.value, c.comment)
+   for c in hdu[ext].header.cards: 
+       odu.header.set(c.keyword, c.value, c.comment)
 
    #write the data out
    saltio.writefits(odu, oimg, clobber=clobber)


### PR DESCRIPTION
This is a fix for using pysalt.ascardslist which has been depreciated and removed in version 3.2.  The salt2iraf tasks has been updated to use astropy.io.fits instead with using the most current wording 
