### PR TITLE
Fixed a bug in specidentify.py

### DIFF
--- a/saltspec/specidentify.py
+++ b/saltspec/specidentify.py
@@ -176,7 +176,7 @@ def specidentify(images,linelist, outfile, guesstype='rss', guessfile='',      \
                    if rstart=='middlerow':
                        ystart=int(0.5*len(data))
                    else:
-                       ystart=rstart
+                       ystart=int(rstart)
 
                    rss.gamma=0.0
                    if masktype=='MOS':


### PR DESCRIPTION
 The rstart variable was defaulting to be a string, so I added an int cast if rstart != 'middlerow'.
