### PR TITLE
Fixing errors that arise when running interactive windows multiple times

### DIFF
--- a/saltspec/InterIdentify.py
+++ b/saltspec/InterIdentify.py
@@ -109,6 +109,7 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         # Set window title
         self.setWindowTitle("InterIdentify")
 
+        
         # create the Image page
         self.imagePage = imageWidget(self.specarr, y1=self.y1, y2=self.y2, hmin=self.hmin, wmin=self.wmin, cmap=self.cmap,
                                      rstep=self.rstep, name=self.filename, scale=self.scale, contrast=self.contrast, log=self.log)
@@ -133,12 +134,14 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         # set up the residual page
         self.errPage = errWidget(self.arcdisplay, hmin=hmin, wmin=wmin)
 
+        
         # create the tabs
         self.tabWidget = QtGui.QTabWidget()
         self.tabWidget.addTab(self.imagePage, 'Image')
         self.tabWidget.addTab(self.arcPage, 'Arc')
         self.tabWidget.addTab(self.errPage, 'Residual')
 
+        
         # layout the widgets
         mainLayout = QtGui.QVBoxLayout(self.main)
         mainLayout.addWidget(self.tabWidget)
@@ -1233,11 +1236,15 @@ def InterIdentify(xarr, specarr, slines, sfluxes, ws, mdiff=20, rstep=1, filenam
                   subback=0, textcolor='green', preprocess=False, log=None, verbose=True):
 
     # Create GUI
-    App = QtGui.QApplication(sys.argv)
+    global App
+    App = QtGui.QApplication.instance()
+    if App is None:
+        App = QtGui.QApplication(sys.argv)
     aw = InterIdentifyWindow(xarr, specarr, slines, sfluxes, ws, rstep=rstep, mdiff=mdiff, sigma=sigma, niter=niter,
                              res=res, dres=dres, dc=dc, ndstep=ndstep, istart=istart, method=method, smooth=smooth,subback=subback,
                              cmap=cmap, scale=scale, contrast=contrast, filename=filename, textcolor=textcolor, preprocess=preprocess, 
                              log=log)
+    
     aw.show()
     # Start application event loop
     exit = App.exec_()
@@ -1250,3 +1257,12 @@ def InterIdentify(xarr, specarr, slines, sfluxes, ws, mdiff=20, rstep=1, filenam
             str(exit))
     del aw
     return imsol
+
+
+
+
+
+
+
+
+

--- a/saltspec/InterIdentify.py
+++ b/saltspec/InterIdentify.py
@@ -109,7 +109,6 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         # Set window title
         self.setWindowTitle("InterIdentify")
 
-        
         # create the Image page
         self.imagePage = imageWidget(self.specarr, y1=self.y1, y2=self.y2, hmin=self.hmin, wmin=self.wmin, cmap=self.cmap,
                                      rstep=self.rstep, name=self.filename, scale=self.scale, contrast=self.contrast, log=self.log)
@@ -134,14 +133,12 @@ class InterIdentifyWindow(QtGui.QMainWindow):
         # set up the residual page
         self.errPage = errWidget(self.arcdisplay, hmin=hmin, wmin=wmin)
 
-        
         # create the tabs
         self.tabWidget = QtGui.QTabWidget()
         self.tabWidget.addTab(self.imagePage, 'Image')
         self.tabWidget.addTab(self.arcPage, 'Arc')
         self.tabWidget.addTab(self.errPage, 'Residual')
 
-        
         # layout the widgets
         mainLayout = QtGui.QVBoxLayout(self.main)
         mainLayout.addWidget(self.tabWidget)
@@ -1257,12 +1254,3 @@ def InterIdentify(xarr, specarr, slines, sfluxes, ws, mdiff=20, rstep=1, filenam
             str(exit))
     del aw
     return imsol
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
When running an interactive specidentify window multiple times, one after another in a for-loop, I came upon some errors that caused my script. The relevant part of my code that caused this exit is:
```python
for f in images:
    #some other code
    iraf.specidentify(images=f, linelist=lamplines, outfile=idfile,
                          guesstype='rss', inter=True, # automethod='FitXcor',
                          rstep=600 / ccdsum,
                          rstart=200 / ccdsum, startext=1, clobber='yes',
                          #startext=1, clobber='yes',
                          verbose='no', mode='hl', logfile='salt.log',
                          mdiff=2, function='legendre')
```

Around the third time going through the loop, I get these messages flooding the terminal:
```
(python:7472): Gtk-CRITICAL **: IA__gtk_container_add: assertion 'GTK_IS_CONTAINER (container)' failed

(python:7472): Gtk-CRITICAL **: IA__gtk_widget_realize: assertion 'GTK_WIDGET_ANCHORED (widget) || GTK_IS_INVISIBLE (widget)' failed

(python:7472): Gtk-CRITICAL **: IA__gtk_widget_realize: assertion 'GTK_WIDGET_ANCHORED (widget) || GTK_IS_INVISIBLE (widget)' failed
```
Then at the fourth time, I get a segmentation fault:
```
2017-05-16 15:01:02 MESSAGE ------------------------------------------
Proccessing extension 1 in  mos/arc*blurred*.fits

Grating	GR-ANGLE	AR-ANGLE	Slit	WCEN	R
PG0900	  20.000	  39.913	1.50	7557.97	1364.187390

Segmentation fault (core dumped)
```
My setup is with pysalt (at the latest current commit #36bd0f6), Ubuntu 15.10, python 2.7. It might be worth mentioning fellow users who run this script on mac OSs don't encounter this issue.

Turns out that, if a script is running more than one QApplication, then deletion of objects may not be consistent. In this case, it's trying to insert widgets into an App that was thoroughly deleted previously. I encountered the solution code in this [stackoverflow question](http://stackoverflow.com/questions/29451285/loading-a-pyqt-application-multiple-times-cause-segmentation-fault).

In my experience, this seems to be an OS specific error, and I believe that my pull does not affect the operability of this pyqt application on other OSs. If someone could test this that would be great since I do not have access to a mac machine for testing. Also, I would recommend this fix to other interactive window apps in this library. 